### PR TITLE
Hotfix CORS headers

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const server = new Hapi.Server({
     routes: {
       cors: {
         origin: ['*'],
-        additionalHeaders: ['x-requested-with']
+        additionalHeaders: ['x-requested-with', 'accept-language']
       }
     }
   }


### PR DESCRIPTION
Chrome sends Accept-Language headers that need to be added to
the list of headers for CORS requests.

Discussion: https://github.com/hapijs/hapi/issues/2986