### PR TITLE
Change type to indicator_type

### DIFF
--- a/routes/indicators/get_indicators.js
+++ b/routes/indicators/get_indicators.js
@@ -15,7 +15,7 @@ module.exports = [
       const query = db('indicators')
         .select('id', 'name', 'created_at', 'updated_at',
           db.raw('data->\'theme\' as theme'),
-          db.raw('data->\'type\' as type')
+          db.raw('data->\'indicator_type\' as type')
         );
 
       if (!req.auth.isAuthenticated) {


### PR DESCRIPTION
This changes the type of the indicator to an object instead of a string. The object has 3 boolean properties: `sds`, `sdg` & `other`

cc @dereklieu 